### PR TITLE
[Fix] View1 상품 이미지 비율 개선 완료

### DIFF
--- a/KREAM/KREAM/Presentation/ReleaseInfoPage/Cells/ReleaseCollectionViewCell.swift
+++ b/KREAM/KREAM/Presentation/ReleaseInfoPage/Cells/ReleaseCollectionViewCell.swift
@@ -54,7 +54,6 @@ final class ReleaseCollectionViewCell: UICollectionViewCell {
          }
          $0.layer.cornerRadius = 10
          $0.layer.borderColor = .none
-         $0.clipsToBounds = true
          $0.contentMode = .scaleAspectFit
       }
       

--- a/KREAM/KREAM/Presentation/ReleaseInfoPage/Cells/ReleaseCollectionViewCell.swift
+++ b/KREAM/KREAM/Presentation/ReleaseInfoPage/Cells/ReleaseCollectionViewCell.swift
@@ -54,6 +54,8 @@ final class ReleaseCollectionViewCell: UICollectionViewCell {
          }
          $0.layer.cornerRadius = 10
          $0.layer.borderColor = .none
+         $0.clipsToBounds = true
+         $0.contentMode = .scaleAspectFit
       }
       
       brandTitle.do {


### PR DESCRIPTION
## 🍦 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
View1 상품영역에서 받아오던 이미지 비율 속성을 수정하였습니다.
## 🍨 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- View1 상품 받아오던 컬렉션뷰 cell의 imageView 속성 값에 
`$0.clipsToBounds = true` 와
`$0.contentMode = .scaleAspectFit` 를 추가하였습니다.

> 24.05.30 `$0.clipsToBounds = true` 값 삭제
- 여경 님의 코드리뷰 반영

## 🥯 Common Changes
<!-- 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요 -->

## 🧁 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/NOW-SOPT-APP4-KREAM/KREAM-iOS/assets/114901417/4aa5d9ec-7629-443a-95c8-866db342a5ee" width ="250">|

## 🍰 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## 🎂 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #66 
